### PR TITLE
Removing unused methods

### DIFF
--- a/ingest/ingestMetadataByDoi.ts
+++ b/ingest/ingestMetadataByDoi.ts
@@ -84,10 +84,6 @@ async function getCitationApa (doi) {
     return apaCitation
 }
 
-function getSimpleName (lastName, firstInitial){
-  return `${lastName}, ${firstInitial}`
-}
-
 function getPublicationYear (csl) {
   // look for both online and print dates, and make newer date win if different
   // put in array sorted by date

--- a/ingest/ingestMetadataByDoi.ts
+++ b/ingest/ingestMetadataByDoi.ts
@@ -69,21 +69,6 @@ async function randomWait(index, seedTime = 1000){
 //   return result.data;
 // }
 
-async function getCitationApa (doi) {
-
-    Cite.async()
-
-    const citeResult = await Cite.inputAsync(doi)
-    const citeObj = new Cite(citeResult)
-
-    // create formatted citation as test
-    const apaCitation = citeObj.format('bibliography', {
-      template: 'apa'
-    })
-    console.log(`Converted DOI: ${doi} to citation: ${apaCitation}`)
-    return apaCitation
-}
-
 function getPublicationYear (csl) {
   // look for both online and print dates, and make newer date win if different
   // put in array sorted by date
@@ -422,7 +407,7 @@ async function loadPersonPapersFromCSV (personMap, path) {
         processedCount += 1
         loopCounter += 1
         //have each wait a pseudo-random amount of time between 1-5 seconds
-        
+
         await randomWait(loopCounter)
 
         //get CSL (citation style language) record by doi from dx.dio.org


### PR DESCRIPTION
## Removing unused `getSimpleName`

133ca5edb75f6e2514236d0c6fd6f8d39edd885f

This method is not used throughout the project.  Instead of commenting
out code, I'm removing that code.

As a matter of reading code, it's hard to determine if commented out
code is intended to be kept around.

I strongly prefer to remove code and leave a meaningful comment to explain.

## Remove `getCitationApa` from ingest

47353e5182c56585287d9d49f906b56bf5c43042

This method is not called in the ingest process.  I see that there's a
potential copy of this method in the client directories.
