### PR TITLE
Extracting normalizeString function to common place and logic path

### DIFF
--- a/ingest/fetchShareData.ts
+++ b/ingest/fetchShareData.ts
@@ -10,6 +10,8 @@ const xmlToJson = require('xml-js');
 const moment = require('moment');
 import pTimes from 'p-times'
 import { randomWait } from './units/randomWait'
+import { removeSpaces, normalizeString } from './units/normalizer'
+
 const getIds = require('./units/joinCsvs').command;
 
 const dataFolderPath = "../data";
@@ -217,45 +219,12 @@ async function getShareSearch (query, curOffset, size) {
   return response.data.hits
 }
 
-// replace diacritics with alphabetic character equivalents
-function removeSpaces (value) {
-  if (_.isString(value)) {
-    const newValue = _.clone(value)
-    let norm =  newValue.replace(/\s/g, '')
-    // console.log(`before replace space: ${value} after replace space: ${norm}`)
-    return norm
-  } else {
-    return value
-  }
-}
-
-function normalizeString (value) {
-  if (_.isString(value)) {
-    const newValue = _.clone(value)
-    const norm1 = newValue
-      .normalize('NFD')
-      .replace(/[\u0300-\u036f]/g, '')
-    // the u0027 also normalizes the curly apostrophe to the straight one
-    const norm2 = norm1.replace(/[\u2019]/g, '\u0027')
-    // remove periods and other remaining special characters
-    const norm3 = norm2.replace(/[&\/\\#,+()$~%.'":*?<>{}!-]/g,'');
-    let norm4 = norm3.replace(' and ', '')
-    // replace any leading 'the' with ''
-    if (_.startsWith(_.toLower(norm4), 'the ')) {
-      norm4 = norm4.substr(4)
-    }
-    return removeSpaces(norm4)
-  } else {
-    return value
-  }
-}
-
 async function writeSearchResult (dataDir, source, startDate, endDate, startIndex, results) {
   let dateString = 'all_dates'
   if (startDate && endDate) {
     dateString = `${startDate}_${endDate}`
   }
-  let sourceString = normalizeString(source)
+  let sourceString = normalizeString(source, { skipLower: true, normalizeTitle: true })
   const filename = path.join(dataDir, `share_metadata_${sourceString}_${dateString}_from_index_${startIndex}.json`);
   if( results && results.length > 0) {
     console.log(`Writing ${filename}`);

--- a/ingest/jestconfig.json
+++ b/ingest/jestconfig.json
@@ -1,0 +1,7 @@
+{
+  "transform": {
+    "^.+\\.(t|j)sx?$": "ts-jest"
+  },
+  "testRegex": "(/tests/.*|(\\.|/)(test|spec))\\.(jsx?|tsx?)$",
+  "moduleFileExtensions": ["ts", "tsx", "js", "jsx", "json", "node"]
+}

--- a/ingest/loadJournalsImpactFactors.ts
+++ b/ingest/loadJournalsImpactFactors.ts
@@ -22,6 +22,7 @@ const pify = require('pify')
 const fs = require('fs')
 const writeCsv = require('./units/writeCsv').command;
 import { randomWait } from './units/randomWait'
+import { removeSpaces, normalizeString } from './units/normalizer'
 
 dotenv.config({
   path: '../.env'
@@ -41,48 +42,13 @@ const client = new ApolloClient({
   cache: new InMemoryCache()
 })
 
-// replace diacritics with alphabetic character equivalents
-function normalizeString (value) {
-  if (_.isString(value)) {
-    const newValue = _.clone(value)
-    const norm1 = newValue
-      .normalize('NFD')
-      .replace(/[\u0300-\u036f]/g, '')
-    // the u0027 also normalizes the curly apostrophe to the straight one
-    const norm2 = norm1.replace(/[\u2019]/g, '\u0027')
-    // remove periods and other remaining special characters
-    const norm3 = norm2.replace(/[&\/\\#,+()$~%.'":*?<>{}!-]/g,'')
-    // replace any 'and' characters in case it is there instead of '&' or vice versa
-    let norm4 = norm3.replace(' and ', '')
-    // replace any leading 'the' with ''
-    if (_.startsWith(_.toLower(norm4), 'the ')) {
-      norm4 = norm4.substr(4)
-    }
-    return removeSpaces(norm4)
-  } else {
-    return value
-  }
-}
-
 // remove diacritic characters (used later for fuzzy matching of names)
 function normalizeObjectProperties (object, properties) {
   const newObject = _.clone(object)
   _.each (properties, (property) => {
-    newObject[property] = normalizeString(newObject[property])
+    newObject[property] = normalizeString(newObject[property], { normalizeTitle: true, skipLower: true })
   })
   return newObject
-}
-
-// replace diacritics with alphabetic character equivalents
-function removeSpaces (value) {
-  if (_.isString(value)) {
-    const newValue = _.clone(value)
-    let norm =  newValue.replace(/\s/g, '')
-    // console.log(`before replace space: ${value} after replace space: ${norm}`)
-    return norm
-  } else {
-    return value
-  }
 }
 
 // remove diacritic characters (used later for fuzzy matching of names)
@@ -114,7 +80,7 @@ function createFuzzyIndex (titleKey, journalMap) {
 
 function journalMatchFuzzy (journalTitle, fuzzyIndex){
   // normalize last name checking against as well
-  const testTitle = normalizeString(journalTitle)
+  const testTitle = normalizeString(journalTitle, { normalizeTitle: true, skipLower: true })
   const journalResults = fuzzyIndex.search(testTitle)
   const reducedResults = _.map(journalResults, (result) => {
     return result['item'] ? result['item'] : result
@@ -235,7 +201,7 @@ async function loadJournalsImpactFactorsFromCSV (csvPathsByYear, journalMap, cur
       factorCounter += 1
       console.log(`${factorCounter} - Checking match for journal factor: ${journalFactorTitle}`)
       let matchedJournal = undefined
-      const testTitle = normalizeString(journalFactorTitle)
+      const testTitle = normalizeString(journalFactorTitle, { normalizeTitle: true, skipLower: true })
       // console.log(`checking test title: ${testTitle}`)
       // console.log(`Journal Map is: ${JSON.stringify(journalMap, null, 2)}`)
       const matchedJournals = journalMatchFuzzy(testTitle, journalFuzzyIndex)
@@ -249,7 +215,7 @@ async function loadJournalsImpactFactorsFromCSV (csvPathsByYear, journalMap, cur
       if (splitJournalTitle.length>1 && splitJournalTitle[0].indexOf(' ') < 0){
         // check to see if has prefix to strip
         otherMatchString = journalFactorTitle.substr(journalFactorTitle.indexOf('-')+1)
-        otherMatchString = normalizeString(otherMatchString)
+        otherMatchString = normalizeString(otherMatchString, { normalizeTitle: true, skipLower: true })
         // console.log(`Checking new match string ${otherMatchString}`)
         otherMatchedJournals = journalMatchFuzzy(otherMatchString, journalFuzzyIndex)
       }

--- a/ingest/package.json
+++ b/ingest/package.json
@@ -36,6 +36,7 @@
     "sanitize-filename": "^1.6.3",
     "schm": "^0.4.1",
     "schm-translate": "^0.4.1",
+    "ts-jest": "^26.4.4",
     "ts-node": "^8.5.2",
     "typescript": "^3.7.2",
     "xml-js": "^1.6.11"
@@ -46,7 +47,7 @@
   "license": "MIT",
   "scripts": {
     "lint": "./node_modules/.bin/eslint loadAuthors.ts --fix",
-    "test": "jest"
+    "test": "jest --config jestconfig.json"
   },
   "devDependencies": {
     "jest": "^26.6.3"

--- a/ingest/units/normalizer.ts
+++ b/ingest/units/normalizer.ts
@@ -1,0 +1,68 @@
+import _ from 'lodash'
+
+/**
+* When the given parameter is a string, return a new string with spaces removed.
+*
+* @param value A string (or any value)
+* @returns A new string with spaces removed (or the given non-String value)
+*/
+export function removeSpaces (value) {
+  if (_.isString(value)) {
+    return _.clone(value).replace(/\s/g, '')
+  } else {
+    return value
+  }
+}
+
+function normalizeTitle(value) {
+  if (_.isString(value)) {
+    return _.clone(value)
+      .replace(/^the /i, '')
+      .replace(' and ', '')
+  } else {
+    return value
+  }
+}
+
+/**
+* Returns a new string with diacritics and "special characters"
+* removed.  If the given `value` is not a string, it returns that value.
+*
+* @remarks See ./tests/normalizer.test.ts for examples
+*
+* @param value A string (or any value)
+* @param options The valid `options` are:
+*                 * removeSpaces: when true remove all spaces
+*                 * skipLower: when true skip lower case conversion
+*                 * normalizeTitle: when true remove " and " and prefix of "the "
+* @returns A new string or the given value
+*/
+export function normalizeString(value, options = {}) {
+  let skipLower = _.get(options, "skipLower", false)
+  let rmSpaces = _.get(options, "removeSpaces", false)
+  let titleNormalization = _.get(options, "normalizeTitle", false)
+  if (_.isString(value)) {
+    let newValue = _.clone(value)
+      .normalize('NFD')
+      .replace(/[\u0300-\u036f]/g, '') // Remove diacritics
+      .replace(/[\u2019]/g, '\u0027') // the u0027 also normalizes the curly apostrophe to the straight one
+      .replace(/[&\/\\#,+()$~%.'":*?<>{}!]/g,'') // remove periods and other remaining special characters
+
+    if (!skipLower) {
+      newValue = _.lowerCase(newValue)
+    }
+
+    if (titleNormalization) {
+      newValue = normalizeTitle(newValue)
+    }
+
+    const returningValue = newValue
+    if (rmSpaces) {
+      return removeSpaces(returningValue)
+    } else {
+      return returningValue
+    }
+  } else {
+    return value
+  }
+}

--- a/ingest/units/test/normalizer.test.ts
+++ b/ingest/units/test/normalizer.test.ts
@@ -1,0 +1,38 @@
+import _ from 'lodash'
+import { removeSpaces, normalizeString } from '../normalizer'
+
+const theNormalizeStringScenarios = [
+  { given: "Björk", expected: "bjork" },
+  { given: 123, expected: 123 },
+  { given: "John-Jacob Jingleheimer‘s Schmidt!", expected: "john jacob jingleheimer s schmidt" },
+  { given: "Wonder wall", options: { removeSpaces: true }, expected: "wonderwall" },
+  { given: "Wonder wäll", options: { removeSpaces: false, skipLower: true }, expected: "Wonder wall" },
+  { given: "The Wonder & wäll", options: { normalizeTitle: true, removeSpaces: true, skipLower: true }, expected: "Wonderwall" },
+  { given: "Then Wonder & wäll", options: { normalizeTitle: true, removeSpaces: true, skipLower: true }, expected: "ThenWonderwall" },
+]
+
+test('normalizeString(): test the various scenarios', () => {
+  expect.hasAssertions();
+  _.each(theNormalizeStringScenarios, (scenario) => {
+    let options = _.get(scenario, "options", {})
+    expect(normalizeString(scenario.given, options)).toEqual(scenario.expected)
+  })
+})
+
+test('normalizeString() without options passed', () => {
+  expect(normalizeString("Björk")).toEqual("bjork")
+})
+
+const theRemoveSpacesScenarios = [
+  { given: "Björk", expected: "Björk" },
+  { given: 123, expected: 123 },
+  { given: "John-Jacob Jingleheimer‘s Schmidt!", expected: "John-JacobJingleheimer‘sSchmidt!" },
+  { given: "Wonder wall", expected: "Wonderwall" }
+]
+
+test('removeSpaces(): test the various scenarios', () => {
+  expect.hasAssertions();
+  _.each(theRemoveSpacesScenarios, (scenario) => {
+    expect(removeSpaces(scenario.given)).toEqual(scenario.expected)
+  })
+})

--- a/ingest/updateAwardsFunders.ts
+++ b/ingest/updateAwardsFunders.ts
@@ -15,6 +15,7 @@ import dotenv from 'dotenv'
 import pMap from 'p-map'
 const Fuse = require('fuse.js')
 import { randomWait } from './units/randomWait'
+import { removeSpaces, normalizeString } from './units/normalizer'
 
 dotenv.config({
   path: '../.env'
@@ -39,42 +40,13 @@ const client = new ApolloClient({
   cache: new InMemoryCache()
 })
 
-// replace diacritics with alphabetic character equivalents
-function normalizeString (value) {
-  if (_.isString(value)) {
-    const newValue = _.clone(value)
-    const norm1 = newValue
-      .normalize('NFD')
-      .replace(/[\u0300-\u036f]/g, '')
-    // the u0027 also normalizes the curly apostrophe to the straight one
-    const norm2 = norm1.replace(/[\u2019]/g, '\u0027')
-    // remove periods and other remaining special characters
-    const norm3 = norm2.replace(/[&\/\\#,+()$~%.'":*?<>{}!-]/g,'');
-    return removeSpaces(norm3)
-  } else {
-    return value
-  }
-}
-
 // remove diacritic characters (used later for fuzzy matching of names)
 function normalizeObjectProperties (object, properties) {
   const newObject = _.clone(object)
   _.each (properties, (property) => {
-    newObject[property] = normalizeString(newObject[property])
+    newObject[property] = normalizeString(newObject[property], { skipLower: true })
   })
   return newObject
-}
-
-// replace diacritics with alphabetic character equivalents
-function removeSpaces (value) {
-  if (_.isString(value)) {
-    const newValue = _.clone(value)
-    let norm =  newValue.replace(/\s/g, '')
-    // console.log(`before replace space: ${value} after replace space: ${norm}`)
-    return norm
-  } else {
-    return value
-  }
 }
 
 // remove diacritic characters (used later for fuzzy matching of names)
@@ -111,7 +83,7 @@ function funderMatchFuzzy (funderName, fuzzyIndex){
   //    return normalizeObjectProperties(funder, [nameKey])
   // })
   // normalize last name checking against as well
-  const testName = normalizeString(funderName)
+  const testName = normalizeString(funderName, { skipLower: true })
 
   // let matchedFunders = []
   // _.each(funderMap, (funder) => {
@@ -219,7 +191,8 @@ async function main (): Promise<void> {
     console.log(`${counter} - Checking award: ${JSON.stringify(award, null, 2)}`)
     let matchedFunder = undefined
     if (award['funder_name']) {
-      const testFunder = normalizeString(award['funder_name'])
+      // TODO: Should this actually skip lower?  Below we have lots of lower case conversions
+      const testFunder = normalizeString(award['funder_name'], { skipLower: true })
       const matchedFunders = funderMatchFuzzy(testFunder, funderFuzzyIndex)
       // const matchedNameFunders = funderMatchFuzzy(testFunder, 'name', funderMap)
       // const matchedSubfunders = funderMatchFuzzy(testFunder, 'name', subfunderMap)

--- a/ingest/updateConfidenceReviewStates.ts
+++ b/ingest/updateConfidenceReviewStates.ts
@@ -21,7 +21,8 @@ import dotenv from 'dotenv'
 import readAllNewPersonPublications from './gql/readAllNewPersonPublications'
 import insertReview from '../client/src/gql/insertReview'
 import readPersonPublicationsByDoi from './gql/readPersonPublicationsByDoi'
-const getIngestFilePathsByYear = require('./getIngestFilePathsByYear');
+const getIngestFilePathsByYear = require('../getIngestFilePathsByYear');
+import { removeSpaces, normalizeString } from '../normalizer'
 
 dotenv.config({
   path: '../.env'
@@ -334,23 +335,6 @@ function getAuthorLastNames (author) {
   return lastNames
 }
 
-// replace diacritics with alphabetic character equivalents
-function normalizeString (value) {
-  if (_.isString(value)) {
-    const newValue = _.clone(value)
-    const norm1 = newValue
-      .normalize('NFD')
-      .replace(/[\u0300-\u036f]/g, '')
-    // the u0027 also normalizes the curly apostrophe to the straight one
-    const norm2 = norm1.replace(/[\u2019]/g, '\u0027')
-    // remove periods and other remaining special characters
-    const norm3 = _.lowerCase(norm2.replace(/[&\/\\#,+()$~%.'":*?<>{}!]/g,''));
-    return norm3
-  } else {
-    return value
-  }
-}
-
 // remove diacritic characters (used later for fuzzy matching of names)
 function normalizeObjectProperties (object, properties) {
   const newObject = _.clone(object)
@@ -358,18 +342,6 @@ function normalizeObjectProperties (object, properties) {
     newObject[property] = normalizeString(newObject[property])
   })
   return newObject
-}
-
-// replace diacritics with alphabetic character equivalents
-function removeSpaces (value) {
-  if (_.isString(value)) {
-    const newValue = _.clone(value)
-    let norm =  newValue.replace(/\s/g, '')
-    // console.log(`before replace space: ${value} after replace space: ${norm}`)
-    return norm
-  } else {
-    return value
-  }
 }
 
 // remove diacritic characters (used later for fuzzy matching of names)

--- a/ingest/updatePublicationsJournals.ts
+++ b/ingest/updatePublicationsJournals.ts
@@ -14,6 +14,8 @@ import pMap from 'p-map'
 import { randomWait } from './units/randomWait'
 const Fuse = require('fuse.js')
 
+import { removeSpaces, normalizeString } from './units/normalizer'
+
 
 dotenv.config({
   path: '../.env'
@@ -40,42 +42,13 @@ const client = new ApolloClient({
   cache: new InMemoryCache()
 })
 
-// replace diacritics with alphabetic character equivalents
-function normalizeString (value) {
-  if (_.isString(value)) {
-    const newValue = _.clone(value)
-    const norm1 = newValue
-      .normalize('NFD')
-      .replace(/[\u0300-\u036f]/g, '')
-    // the u0027 also normalizes the curly apostrophe to the straight one
-    const norm2 = norm1.replace(/[\u2019]/g, '\u0027')
-    // remove periods and other remaining special characters
-    const norm3 = norm2.replace(/[&\/\\#,+()$~%.'":*?<>{}!]/g,'');
-    return removeSpaces(norm3)
-  } else {
-    return value
-  }
-}
-
 // remove diacritic characters (used later for fuzzy matching of names)
 function normalizeObjectProperties (object, properties) {
   const newObject = _.clone(object)
   _.each (properties, (property) => {
-    newObject[property] = normalizeString(newObject[property])
+    newObject[property] = normalizeString(newObject[property], { removeSpaces: true, skipLower: true })
   })
   return newObject
-}
-
-// replace diacritics with alphabetic character equivalents
-function removeSpaces (value) {
-  if (_.isString(value)) {
-    const newValue = _.clone(value)
-    let norm =  newValue.replace(/\s/g, '')
-    // console.log(`before replace space: ${value} after replace space: ${norm}`)
-    return norm
-  } else {
-    return value
-  }
 }
 
 // remove diacritic characters (used later for fuzzy matching of names)
@@ -93,7 +66,7 @@ function journalMatchFuzzy (journalTitle, titleKey, journalMap){
      return normalizeObjectProperties(journal, [titleKey])
   })
   // normalize last name checking against as well
-  const testTitle = normalizeString(journalTitle)
+  const testTitle = normalizeString(journalTitle, { removeSpaces: true, skipLower: true })
   // console.log(`After diacritic switch ${JSON.stringify(nameMap, null, 2)} converted to: ${JSON.stringify(testNameMap, null, 2)}`)
   const lastFuzzy = new Fuse(journalMap, {
     caseSensitive: false,
@@ -145,7 +118,7 @@ async function main (): Promise<void> {
     console.log(`${pubCounter} - Checking publication id: ${publication['id']}`)
     let matchedJournal = undefined
     if (publication['journal_title']) {
-      const testTitle = normalizeString(publication['journal_title'])
+      const testTitle = normalizeString(publication['journal_title'], { removeSpaces: true, skipLower: true })
       const matchedJournals = journalMatchFuzzy(testTitle, 'title', journalMap)
       let matchedInfo = {
         'doi': publication['doi'],

--- a/ingest/yarn.lock
+++ b/ingest/yarn.lock
@@ -703,6 +703,14 @@
   dependencies:
     "@types/istanbul-lib-report" "*"
 
+"@types/jest@26.x":
+  version "26.0.15"
+  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-26.0.15.tgz#12e02c0372ad0548e07b9f4e19132b834cb1effe"
+  integrity sha512-s2VMReFXRg9XXxV+CW9e5Nz8fH2K1aEhwgjUqPPbQd7g95T0laAcvLv032EhFHIa5GHsZ8W7iJEQVaJq6k3Gog==
+  dependencies:
+    jest-diff "^26.0.0"
+    pretty-format "^26.0.0"
+
 "@types/json-schema@^7.0.3":
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.3.tgz#bdfd69d61e464dcc81b25159c270d75a73c1a636"
@@ -1233,6 +1241,13 @@ browser-process-hrtime@^1.0.0:
   resolved "https://registry.yarnpkg.com/browser-process-hrtime/-/browser-process-hrtime-1.0.0.tgz#3c9b4b7d782c8121e56f10106d84c0d0ffc94626"
   integrity sha512-9o5UecI3GhkpM6DrXr69PblIuWxPKk9Y0jHBRhdocZ2y7YECBFCsHm79Pr3OyR2AvjhDkabFJaDJMYRazHgsow==
 
+bs-logger@0.x:
+  version "0.2.6"
+  resolved "https://registry.yarnpkg.com/bs-logger/-/bs-logger-0.2.6.tgz#eb7d365307a72cf974cc6cda76b68354ad336bd8"
+  integrity sha512-pd8DCoxmbgc7hyPKOvxtqNcjYoOsABPQdcCUjGp3d42VR2CX1ORhk2A87oqqu5R1kk+76nsxZupkmyd+MVtCog==
+  dependencies:
+    fast-json-stable-stringify "2.x"
+
 bser@2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/bser/-/bser-2.1.1.tgz#e6787da20ece9d07998533cfd9de6f5c38f4bc05"
@@ -1240,7 +1255,7 @@ bser@2.1.1:
   dependencies:
     node-int64 "^0.4.0"
 
-buffer-from@^1.0.0:
+buffer-from@1.x, buffer-from@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.1.tgz#32713bc028f75c02fdb710d7c7bcec1f2c6070ef"
   integrity sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==
@@ -2072,6 +2087,11 @@ fast-deep-equal@^3.1.1:
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
   integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
 
+fast-json-stable-stringify@2.x:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz#874bf69c6f404c2b5d99c481341399fd55892633"
+  integrity sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==
+
 fast-json-stable-stringify@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz#d5142c0caee6b1189f87d3a76111064f86c8bbf2"
@@ -2842,7 +2862,7 @@ jest-config@^26.6.3:
     micromatch "^4.0.2"
     pretty-format "^26.6.2"
 
-jest-diff@^26.6.2:
+jest-diff@^26.0.0, jest-diff@^26.6.2:
   version "26.6.2"
   resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-26.6.2.tgz#1aa7468b52c3a68d7d5c5fdcdfcd5e49bd164394"
   integrity sha512-6m+9Z3Gv9wN0WFVasqjCL/06+EFCMTqDEUl/b87HYK2rAPTyfz4ZIuSlPhY51PIQRWx5TaxeF1qmXKe9gfN3sA==
@@ -3108,7 +3128,7 @@ jest-snapshot@^26.6.2:
     pretty-format "^26.6.2"
     semver "^7.3.2"
 
-jest-util@^26.6.2:
+jest-util@^26.1.0, jest-util@^26.6.2:
   version "26.6.2"
   resolved "https://registry.yarnpkg.com/jest-util/-/jest-util-26.6.2.tgz#907535dbe4d5a6cb4c47ac9b926f6af29576cbc1"
   integrity sha512-MDW0fKfsn0OI7MS7Euz6h8HNDXVQ0gaM9uW6RjfDmd1DAFcaxX9OqIakHIqhbnmF08Cf2DLDG+ulq8YQQ0Lp0Q==
@@ -3243,7 +3263,7 @@ json-stringify-safe@~5.0.1:
   resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
   integrity sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=
 
-json5@^2.1.2:
+json5@2.x, json5@^2.1.2:
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/json5/-/json5-2.1.3.tgz#c9b0f7fa9233bfe5807fe66fcf3a5617ed597d43"
   integrity sha512-KXPvOm8K9IJKFM0bmdn8QXh7udDh1g/giieX0NLCaMnb4hEiVFqnop2ImTXCc5e0/oHz3LTqmHGtExn5hfMkOA==
@@ -3339,6 +3359,11 @@ locate-path@^5.0.0:
   dependencies:
     p-locate "^4.1.0"
 
+lodash.memoize@4.x:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"
+  integrity sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=
+
 lodash.sortby@^4.7.0:
   version "4.7.0"
   resolved "https://registry.yarnpkg.com/lodash.sortby/-/lodash.sortby-4.7.0.tgz#edd14c824e2cc9c1e0b0a1b42bb5210516a42438"
@@ -3373,6 +3398,11 @@ make-dir@^3.0.0:
   integrity sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==
   dependencies:
     semver "^6.0.0"
+
+make-error@1.x:
+  version "1.3.6"
+  resolved "https://registry.yarnpkg.com/make-error/-/make-error-1.3.6.tgz#2eb2e37ea9b67c4891f684a1394799af484cf7a2"
+  integrity sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==
 
 make-error@^1.1.1:
   version "1.3.5"
@@ -3471,6 +3501,11 @@ mixin-deep@^1.2.0:
   dependencies:
     for-in "^1.0.2"
     is-extendable "^1.0.1"
+
+mkdirp@1.x:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
+  integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
 
 mkdirp@^0.5.1:
   version "0.5.1"
@@ -3904,7 +3939,7 @@ prelude-ls@~1.1.2:
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
   integrity sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=
 
-pretty-format@^26.6.2:
+pretty-format@^26.0.0, pretty-format@^26.6.2:
   version "26.6.2"
   resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-26.6.2.tgz#e35c2705f14cb7fe2fe94fa078345b444120fc93"
   integrity sha512-7AeGuCYNGmycyQbCqd/3PWH4eOoX/OiCa0uphp57NVTeAGdJGaAliecxwBDHYQCIvrW7aDBZCYeNTP/WX69mkg==
@@ -4244,15 +4279,15 @@ schm@^0.4.1:
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
   integrity sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==
 
+semver@7.x, semver@^7.3.2:
+  version "7.3.2"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.2.tgz#604962b052b81ed0786aae84389ffba70ffd3938"
+  integrity sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==
+
 semver@^6.0.0, semver@^6.1.0, semver@^6.1.2, semver@^6.3.0:
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
-
-semver@^7.3.2:
-  version "7.3.2"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.2.tgz#604962b052b81ed0786aae84389ffba70ffd3938"
-  integrity sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==
 
 set-blocking@^2.0.0:
   version "2.0.0"
@@ -4719,6 +4754,23 @@ ts-invariant@^0.4.0:
   dependencies:
     tslib "^1.9.3"
 
+ts-jest@^26.4.4:
+  version "26.4.4"
+  resolved "https://registry.yarnpkg.com/ts-jest/-/ts-jest-26.4.4.tgz#61f13fb21ab400853c532270e52cc0ed7e502c49"
+  integrity sha512-3lFWKbLxJm34QxyVNNCgXX1u4o/RV0myvA2y2Bxm46iGIjKlaY0own9gIckbjZJPn+WaJEnfPPJ20HHGpoq4yg==
+  dependencies:
+    "@types/jest" "26.x"
+    bs-logger "0.x"
+    buffer-from "1.x"
+    fast-json-stable-stringify "2.x"
+    jest-util "^26.1.0"
+    json5 "2.x"
+    lodash.memoize "4.x"
+    make-error "1.x"
+    mkdirp "1.x"
+    semver "7.x"
+    yargs-parser "20.x"
+
 ts-node@^8.5.2:
   version "8.5.2"
   resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-8.5.2.tgz#434f6c893bafe501a30b32ac94ee36809ba2adce"
@@ -5029,6 +5081,11 @@ yallist@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-2.1.2.tgz#1c11f9218f076089a47dd512f93c6699a6a81d52"
   integrity sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=
+
+yargs-parser@20.x:
+  version "20.2.4"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-20.2.4.tgz#b42890f14566796f85ae8e3a25290d205f154a54"
+  integrity sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA==
 
 yargs-parser@^18.1.2:
   version "18.1.3"


### PR DESCRIPTION
## Adding jest configuration for typescript

9c527b98d4f177383218e900f61b970722863ba7

Using guidance from https://github.com/ndlib/ndlib-cdk, these are the
necessary changes to get tests up and running.

## Adding normalizer functions with tests

b2d74b9ee47bb23bc9b615b26fab53ce2dafcfda

Throughout the ingest code-base there are a few flavors of string
normalization.  The `removeSpaces()`, `normalizeTitle()`, and
`normalizeString()` functions represent those permutations.

The tests demonstrate how those permutations happen.

## Refactoring normalizeString to use common function

a72f33de6500f3f3c0d7e40f79a7586a701af9a9

Prior to this commit, each of these functions had slight implementation
variations, but quite a bit of common implementation details.

This refactor pushes that logic to a shared string normalization
function, thus improving maintainability and improving expressiveness of
what is happening.
