### PR TITLE
Extracting a getAllSimplifiedPersons function

### DIFF
--- a/ingest/ingestMetadataByDoi.ts
+++ b/ingest/ingestMetadataByDoi.ts
@@ -6,8 +6,6 @@ import { createHttpLink } from 'apollo-link-http'
 import fetch from 'node-fetch'
 import pEachSeries from 'p-each-series'
 import readUsers from '../client/src/gql/readPersons'
-import readPersonsByYear from '../client/src/gql/readPersonsByYear'
-import readPersons from '../client/src/gql/readPersons'
 import insertPublication from './gql/insertPublication'
 import insertPersonPublication from './gql/insertPersonPublication'
 import insertPubAuthor from './gql/insertPubAuthor'
@@ -22,6 +20,7 @@ import { randomWait } from './units/randomWait'
 import dotenv from 'dotenv'
 import readPublicationsByDoi from './gql/readPublicationsByDoi'
 import readPersonPublicationsByDoi from './gql/readPersonPublicationsByDoi'
+import { getAllSimplifiedPersons } from './modules/queryNormalizedPeople'
 // import insertReview from '../client/src/gql/insertReview'
 
 dotenv.config({
@@ -141,40 +140,6 @@ async function insertPublicationAndAuthors (title, doi, csl, authors, sourceName
     console.log(error)
     throw error
   }
-}
-
-interface SimplifiedPerson {
-  id: number;
-  lastName: string;
-  firstInitial: string;
-  firstName: string;
-  startYear: string;
-  endYear: string;
-}
-
-function mapToSimplifiedPeople(people) : Array<SimplifiedPerson> {
-  const simplifiedPersons = _.map(people, (person) => {
-    let sp: SimplifiedPerson = {
-      id: person.id,
-      lastName: _.lowerCase(person.family_name),
-      firstInitial: _.lowerCase(person.given_name[0]),
-      firstName: _.lowerCase(person.given_name),
-      startYear: person.start_date,
-      endYear: person.end_date
-    }
-    return sp
-  })
-  return simplifiedPersons
-}
-
-async function getAllSimplifiedPersons() : Promise<Array<SimplifiedPerson>> {
-  const queryResult = await client.query(readPersons())
-  return mapToSimplifiedPeople(queryResult.data.persons)
-}
-
-async function getSimplifiedPersonsByYear(year: number) : Promise<Array<SimplifiedPerson>> {
-  const queryResult = await client.query(readPersonsByYear(year))
-  return mapToSimplifiedPeople(queryResult.data.persons)
 }
 
 async function getPapersByDoi (csvPath: string) {
@@ -582,7 +547,7 @@ async function main() {
   const pathsByYear = await getIngestFilePathsByYear()
 
   //just get all simplified persons as will filter later
-  const simplifiedPersons = await getAllSimplifiedPersons()
+  const simplifiedPersons = await getAllSimplifiedPersons(client)
 
   let doiStatus = new Map()
   await pMap(_.keys(pathsByYear), async (year) => {

--- a/ingest/loadAbstracts.ts
+++ b/ingest/loadAbstracts.ts
@@ -36,26 +36,6 @@ const client = new ApolloClient({
   cache: new InMemoryCache()
 })
 
-async function getAllSimplifiedPersons () {
-  const queryResult = await client.query(readPersons())
-
-  const simplifiedPersons = _.map(queryResult.data.persons, (person) => {
-    return {
-      id: person.id,
-      lastName: person.family_name.toLowerCase(),
-      firstInitial: person.given_name[0].toLowerCase(),
-      firstName: person.given_name.toLowerCase(),
-      startYear: person.start_date,
-      endYear: person.end_date
-    }
-  })
-  return simplifiedPersons
-}
-
-function getNameKey (lastName, firstName) {
-  return `${_.toLower(lastName)}, ${_.toLower(firstName)}`
-}
-
 async function getScopusPaperAbstractData (pii) {
   const baseUrl = `https://api.elsevier.com/content/article/pii/${pii}`
   console.log(`Base url is: ${baseUrl}`)

--- a/ingest/loadAwards.ts
+++ b/ingest/loadAwards.ts
@@ -12,6 +12,7 @@ import { __EnumValue } from 'graphql'
 import dotenv from 'dotenv'
 import pMap from 'p-map'
 import { randomWait } from './units/randomWait'
+import { getAllSimplifiedPersons } from './modules/queryNormalizedPeople'
 
 dotenv.config({
   path: '../.env'
@@ -32,26 +33,6 @@ const client = new ApolloClient({
   }),
   cache: new InMemoryCache()
 })
-
-async function getAllSimplifiedPersons () {
-  const queryResult = await client.query(readPersons())
-
-  const simplifiedPersons = _.map(queryResult.data.persons, (person) => {
-    return {
-      id: person.id,
-      lastName: person.family_name.toLowerCase(),
-      firstInitial: person.given_name[0].toLowerCase(),
-      firstName: person.given_name.toLowerCase(),
-      startYear: person.start_date,
-      endYear: person.end_date
-    }
-  })
-  return simplifiedPersons
-}
-
-function getNameKey (lastName, firstName) {
-  return `${_.toLower(lastName)}, ${_.toLower(firstName)}`
-}
 
 async function getPublications () {
   const queryResult = await client.query(readPublicationsAwards())

--- a/ingest/modules/queryNormalizedPeople.ts
+++ b/ingest/modules/queryNormalizedPeople.ts
@@ -1,0 +1,46 @@
+import readPersons from '../../client/src/gql/readPersons'
+import readPersonsByYear from '../client/src/gql/readPersonsByYear'
+import _ from 'lodash'
+
+// This set of functions provide common methods for retrieving a
+// SimplifiedPerson.
+
+// @todo compare to normedPerson.ts; note this has startYear, endYear
+// and normedPerson.ts has startDate and endDate
+interface SimplifiedPerson {
+  id: number;
+  lastName: string;
+  firstInitial: string;
+  firstName: string;
+  startYear: string;
+  endYear: string;
+}
+
+function mapToSimplifiedPeople(people: Array<any>) : Array<SimplifiedPerson> {
+  const simplifiedPersons = _.map(people, (person) => {
+    let sp: SimplifiedPerson = {
+      id: person.id,
+      lastName: _.lowerCase(person.family_name),
+      firstInitial: _.lowerCase(person.given_name[0]),
+      firstName: _.lowerCase(person.given_name),
+      startYear: person.start_date,
+      endYear: person.end_date
+    }
+    return sp
+  })
+  return simplifiedPersons
+}
+
+export function getNameKey (lastName: string, firstName: string) : string {
+  return `${_.toLower(lastName)}, ${_.toLower(firstName)}`
+}
+
+export async function getAllSimplifiedPersons (client: ApolloClient) : Promise<Array<SimplifiedPerson>> {
+  const queryResult = await client.query(readPersons())
+  return mapToSimplifiedPeople(queryResult.data.persons)
+}
+
+export async function getSimplifiedPersonsByYear(year: number, client: ApolloClient) : Promise<Array<SimplifiedPerson>> {
+  const queryResult = await client.query(readPersonsByYear(year))
+  return mapToSimplifiedPeople(queryResult.data.persons)
+}

--- a/ingest/updateConfidenceReviewStates.ts
+++ b/ingest/updateConfidenceReviewStates.ts
@@ -900,7 +900,7 @@ async function main() {
   const pathsByYear = await getIngestFilePathsByYear("../admin/config/ingestConfidenceReviewFilePaths.json")
 
   // get the set of persons to test
-  const testAuthors = await getAllSimplifiedPersons()
+  const testAuthors = await getAllSimplifiedPersons(client)
   //create map of last name to array of related persons with same last name
   const personMap = _.transform(testAuthors, function (result, value) {
     _.each(value.names, (name) => {


### PR DESCRIPTION
## Extracting a getAllSimplifiedPersons function

caf9c15ef79b79d7fe5d4312ecb9fa3f389e148a

This function was common throughout the updated files.  Instead of
having variance, I want to normalize these functions.

One thing that I'm dis-satisfied with is that there are lots of
ApolloClient declarations.  To resolve this for the extraction of a
common method, I went with dependency injection.

I don't know the best way to proceed with this, but for now this change
should be logically equivalent to the code state prior to this commit.

Also, I extracted what appeared to be another "normalize the data" kind
of method associated with the simplified person.

NOTE: There remains a `getAllSimplifiedPersons()` that is different in
its inner logic.  I'm uncertain if that is a refinement that should
propogate to other locations or if it is a specific implementation.
